### PR TITLE
Fix failing subtitles

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -37,7 +37,7 @@ const defaultConfig = {
   subtitleLanguages: ['English', 'Spanish', 'German'],
   title: '',
   saveMedia: true,
-  skipNoSubtitles: false,
+  skipNoSubtitles: true,
   torrentListLength: 30,
   downloadDir: path.join(os.homedir(), 'Downloads'),
   configFile: getCfgFile(),

--- a/src/utils/gets.ts
+++ b/src/utils/gets.ts
@@ -176,8 +176,13 @@ export async function getSubtitleFile(
   cfg: typeof defaultConfig,
   subtitle: subtitle
 ) {
-  return new Promise<string>(async (resolve, _reject) => {
+  return new Promise<string>(async (resolve, reject) => {
     let stream: fs.WriteStream
+
+    if (cfg.skipNoSubtitles && !subtitle) {
+      resolve('')
+      return
+    }
 
     const content = await (await fetch(subtitle.url)).text()
     if (cfg.saveMedia) {
@@ -208,10 +213,15 @@ export async function getSubtitleFile(
       resolve(stream.path.toString())
     })
     stream.on('error', (err) => {
-      console.info(
-        c.yellow('Warning: Could not download subtitles file. Ignoring')
-      )
-      if (isDebug()) console.error(err)
+      if (cfg.skipNoSubtitles) {
+        console.info(
+          c.yellow('Warning: Could not download subtitles file. Ignoring')
+        )
+        if (isDebug()) console.error(err)
+        resolve('')
+      } else {
+        reject(err)
+      }
     })
   })
 }

--- a/src/utils/gets.ts
+++ b/src/utils/gets.ts
@@ -174,13 +174,17 @@ export async function getSubtitles(
 
 export async function getSubtitleFile(
   cfg: typeof defaultConfig,
-  subtitle: subtitle
+  subtitle?: subtitle
 ) {
   return new Promise<string>(async (resolve, reject) => {
     let stream: fs.WriteStream
 
-    if (cfg.skipNoSubtitles && !subtitle) {
-      resolve('')
+    if (!subtitle) {
+      if (cfg.skipNoSubtitles) {
+        resolve('')
+      } else {
+        reject(new Error('No subtitle object was provided'))
+      }
       return
     }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -100,7 +100,8 @@ export function init() {
   const signals: NodeJS.Signals[] = ['SIGINT', 'SIGHUP']
   for (const signal of signals) {
     process.on(signal, async (_sig) => {
-      await cleanupTemp()
+      // If we don't catch, any error from cleanupTemp() will prevent the requested exit.
+      await cleanupTemp().catch(console.error)
 
       process.exit(1)
     })


### PR DESCRIPTION
OpenSubtitles has been failing for a week or two.

This has resulted in cliflix bailing with the following error:

```
Warning: Could not search for subtitles with OpenSubtitles. Ignoring
TypeError: Cannot read property 'url' of undefined
    at /home/joey/SYNC/src/cliflix/dist/utils/gets.js:133:68
    at new Promise (<anonymous>)
    at Object.getSubtitleFile (/home/joey/SYNC/src/cliflix/dist/utils/gets.js:131:12)
    at Object.doWizard (/home/joey/SYNC/src/cliflix/dist/actions/doWizard.js:41:37)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async Object.handler (/home/joey/SYNC/src/cliflix/dist/cli.js:39:13)
```

I added some code to fix this.

I guess it's now passing `--subtitles ''` to webtorrent, but that seems to work well enough!

I also made `skipNoSubtitles` do what I expected it should do, and then made it default it to `true` for a friendlier user experience.